### PR TITLE
OpenShift CLI tool link update to 4.x

### DIFF
--- a/src/pages/getting-started/devenvsetup/index.mdx
+++ b/src/pages/getting-started/devenvsetup/index.mdx
@@ -109,7 +109,7 @@ The following is a list of desktop tools required to help with installation and 
     ```
     - Note: If you log in to the web UI using SSO, you'll need to [create an API key](https://cloud.ibm.com/docs/iam?topic=iam-federated_id) for logging into the CLI. (You can also use this API key for [installing the Developer Tools environment](/admin/installation-ibm-cloud).)
 
-- [OpenShift OC CLI](https://www.okd.io/download.html): Required for Red Hat OpenShift management and development
+- [OpenShift OC CLI](https://mirror.openshift.com/pub/openshift-v4/clients/oc/): Required for Red Hat OpenShift management and development, select 4.3.18 or later version.
     - Place `oc` and `kubectl` in your Terminal `PATH`
 
     - #### MacOS/Linux


### PR DESCRIPTION
Update link from okd 3.x CLI to official mirror from Red Hat for all 4.x versions. Suggest version 4.3.18 or later for compatibility with ROKS as of June, 2020.

fixes #89 