### PR TITLE
remote try-it from foundation cd

### DIFF
--- a/src/pages/developer-foundation/continuous-delivery/index.mdx
+++ b/src/pages/developer-foundation/continuous-delivery/index.mdx
@@ -79,10 +79,6 @@ These tasks assume that you have:
 | *** Walkthroughs ***                         |         |         |     |
 | GitOps | Introduction to GitOps with OpenShift | [Learn OpenShift](https://learn.openshift.com/introduction/gitops-introduction/) | 20 min |
 | GitOps Multi-cluster | Multi-cluster GitOps with OpenShift | [Learn OpenShift](https://learn.openshift.com/introduction/gitops-multicluster/) | 20 min |
-| *** Try It Yourself ***                         |         |         |     |
-| ArgoCD Lab | Learn how to setup ArgoCD and Deploy Application | [ArgoCD](../developer-foundation/continuous-delivery/activities/) | 30 min |
-
-
 
 Once you have completed these tasks, you will have created an ArgoCD deployment and have an understanding of Continuous Deployment.
 


### PR DESCRIPTION
In the Foundations CD content, keep walkthroughs (point to katacoda) drop Argo hands-on and reserve for Intermediate topics.